### PR TITLE
SKEL-15: Create tabs component

### DIFF
--- a/modules/custom/skeletor_accordion/config/install/block_content.type.skeletor_accordion.yml
+++ b/modules/custom/skeletor_accordion/config/install/block_content.type.skeletor_accordion.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: skeletor_accordion
+label: Accordion
+revision: 0
+description: 'Create accordion block using Skeletor accordion component.'

--- a/modules/custom/skeletor_accordion/config/install/core.entity_form_display.block_content.skeletor_accordion.default.yml
+++ b/modules/custom/skeletor_accordion/config/install/core.entity_form_display.block_content.skeletor_accordion.default.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.skeletor_accordion
+    - field.field.block_content.skeletor_accordion.field_component_accordion
+  module:
+    - paragraphs
+id: block_content.skeletor_accordion.default
+targetEntityType: block_content
+bundle: skeletor_accordion
+mode: default
+content:
+  field_component_accordion:
+    type: entity_reference_paragraphs
+    weight: 2
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+    third_party_settings: {  }
+    region: content
+  info:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 1
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/custom/skeletor_accordion/config/install/core.entity_form_display.paragraph.component_accordion.component_no_title.yml
+++ b/modules/custom/skeletor_accordion/config/install/core.entity_form_display.paragraph.component_accordion.component_no_title.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.paragraph.component_no_title
+    - field.field.paragraph.component_accordion.field_accordion_items
+    - field.field.paragraph.component_accordion.field_component_accordion_title
+    - paragraphs.paragraphs_type.component_accordion
+  module:
+    - paragraphs
+id: paragraph.component_accordion.component_no_title
+targetEntityType: paragraph
+bundle: component_accordion
+mode: component_no_title
+content:
+  field_accordion_items:
+    type: entity_reference_paragraphs
+    weight: 0
+    settings:
+      title: Item
+      title_plural: Items
+      edit_mode: open
+      add_mode: button
+      form_display_mode: default
+      default_paragraph_type: component_accordion_item
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_component_accordion_title: true
+  status: true
+  uid: true

--- a/modules/custom/skeletor_accordion/config/install/core.entity_view_display.block_content.skeletor_accordion.default.yml
+++ b/modules/custom/skeletor_accordion/config/install/core.entity_view_display.block_content.skeletor_accordion.default.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.skeletor_accordion
+    - field.field.block_content.skeletor_accordion.field_component_accordion
+  module:
+    - entity_reference_revisions
+id: block_content.skeletor_accordion.default
+targetEntityType: block_content
+bundle: skeletor_accordion
+mode: default
+content:
+  field_component_accordion:
+    type: entity_reference_revisions_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/modules/custom/skeletor_accordion/config/install/core.entity_view_display.paragraph.component_accordion.component_no_title.yml
+++ b/modules/custom/skeletor_accordion/config/install/core.entity_view_display.paragraph.component_accordion.component_no_title.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.component_no_title
+    - field.field.paragraph.component_accordion.field_accordion_items
+    - field.field.paragraph.component_accordion.field_component_accordion_title
+    - paragraphs.paragraphs_type.component_accordion
+  module:
+    - entity_reference_revisions
+id: paragraph.component_accordion.component_no_title
+targetEntityType: paragraph
+bundle: component_accordion
+mode: component_no_title
+content:
+  field_accordion_items:
+    type: entity_reference_revisions_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_component_accordion_title: true

--- a/modules/custom/skeletor_accordion/config/install/field.field.block_content.skeletor_accordion.field_component_accordion.yml
+++ b/modules/custom/skeletor_accordion/config/install/field.field.block_content.skeletor_accordion.field_component_accordion.yml
@@ -1,0 +1,60 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.skeletor_accordion
+    - field.storage.block_content.field_component_accordion
+    - paragraphs.paragraphs_type.component_accordion
+  module:
+    - entity_reference_revisions
+id: block_content.skeletor_accordion.field_component_accordion
+field_name: field_component_accordion
+entity_type: block_content
+bundle: skeletor_accordion
+label: Accordion
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      component_accordion: component_accordion
+    target_bundles_drag_drop:
+      component_accordion:
+        enabled: true
+        weight: 12
+      component_accordion_item:
+        weight: 13
+        enabled: false
+      component_accordion_item_content:
+        weight: 14
+        enabled: false
+      component_hero:
+        weight: 15
+        enabled: false
+      component_hero_text:
+        weight: 16
+        enabled: false
+      component_tab:
+        weight: 17
+        enabled: false
+      component_tab_content:
+        weight: 18
+        enabled: false
+      component_tab_title:
+        weight: 19
+        enabled: false
+      component_tabs:
+        weight: 20
+        enabled: false
+      component_text:
+        weight: 21
+        enabled: false
+      component_title:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/modules/custom/skeletor_accordion/config/install/field.storage.block_content.field_component_accordion.yml
+++ b/modules/custom/skeletor_accordion/config/install/field.storage.block_content.field_component_accordion.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - entity_reference_revisions
+    - paragraphs
+id: block_content.field_component_accordion
+field_name: field_component_accordion
+entity_type: block_content
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/skeletor_accordion/config/install/language.content_settings.block_content.skeletor_accordion.yml
+++ b/modules/custom/skeletor_accordion/config/install/language.content_settings.block_content.skeletor_accordion.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.skeletor_accordion
+id: block_content.skeletor_accordion
+target_entity_type_id: block_content
+target_bundle: skeletor_accordion
+default_langcode: site_default
+language_alterable: false

--- a/modules/custom/skeletor_accordion/config/install/paragraphs.paragraphs_type.component_accordion.yml
+++ b/modules/custom/skeletor_accordion/config/install/paragraphs.paragraphs_type.component_accordion.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_accordion
-label: Accordion
+label: 'Accordion Component'
 icon_uuid: null
 description: 'Wrapper for multiple accordion items.'
 behavior_plugins: {  }

--- a/modules/custom/skeletor_accordion/skeletor_accordion.info.yml
+++ b/modules/custom/skeletor_accordion/skeletor_accordion.info.yml
@@ -3,8 +3,10 @@ description: 'Accordion component for skeletor profile.'
 type: module
 core: 8.x
 dependencies:
+  - block_content
   - entity_reference_revisions
   - field
+  - language
   - paragraphs
   - skeletor_title_component
   - text

--- a/modules/custom/skeletor_hero/config/install/block_content.type.skeletor_hero.yml
+++ b/modules/custom/skeletor_hero/config/install/block_content.type.skeletor_hero.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: skeletor_hero
+label: Hero
+revision: 0
+description: 'Create hero block using Skeletor hero component.'

--- a/modules/custom/skeletor_hero/config/install/core.entity_form_display.block_content.skeletor_hero.default.yml
+++ b/modules/custom/skeletor_hero/config/install/core.entity_form_display.block_content.skeletor_hero.default.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.skeletor_hero
+    - field.field.block_content.skeletor_hero.field_component_hero
+  module:
+    - paragraphs
+id: block_content.skeletor_hero.default
+targetEntityType: block_content
+bundle: skeletor_hero
+mode: default
+content:
+  field_component_hero:
+    type: entity_reference_paragraphs
+    weight: 27
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+    third_party_settings: {  }
+    region: content
+  info:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/custom/skeletor_hero/config/install/core.entity_view_display.block_content.skeletor_hero.default.yml
+++ b/modules/custom/skeletor_hero/config/install/core.entity_view_display.block_content.skeletor_hero.default.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.skeletor_hero
+    - field.field.block_content.skeletor_hero.field_component_hero
+  module:
+    - entity_reference_revisions
+id: block_content.skeletor_hero.default
+targetEntityType: block_content
+bundle: skeletor_hero
+mode: default
+content:
+  field_component_hero:
+    type: entity_reference_revisions_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/modules/custom/skeletor_hero/config/install/field.field.block_content.skeletor_hero.field_component_hero.yml
+++ b/modules/custom/skeletor_hero/config/install/field.field.block_content.skeletor_hero.field_component_hero.yml
@@ -1,0 +1,60 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.skeletor_hero
+    - field.storage.block_content.field_component_hero
+    - paragraphs.paragraphs_type.component_hero
+  module:
+    - entity_reference_revisions
+id: block_content.skeletor_hero.field_component_hero
+field_name: field_component_hero
+entity_type: block_content
+bundle: skeletor_hero
+label: Hero
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      component_hero: component_hero
+    target_bundles_drag_drop:
+      component_accordion:
+        weight: 12
+        enabled: false
+      component_accordion_item:
+        weight: 13
+        enabled: false
+      component_accordion_item_content:
+        weight: 14
+        enabled: false
+      component_hero:
+        enabled: true
+        weight: 15
+      component_hero_text:
+        weight: 16
+        enabled: false
+      component_tab:
+        weight: 17
+        enabled: false
+      component_tab_content:
+        weight: 18
+        enabled: false
+      component_tab_title:
+        weight: 19
+        enabled: false
+      component_tabs:
+        weight: 20
+        enabled: false
+      component_text:
+        weight: 21
+        enabled: false
+      component_title:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/modules/custom/skeletor_hero/config/install/field.storage.block_content.field_component_hero.yml
+++ b/modules/custom/skeletor_hero/config/install/field.storage.block_content.field_component_hero.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - entity_reference_revisions
+    - paragraphs
+id: block_content.field_component_hero
+field_name: field_component_hero
+entity_type: block_content
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/skeletor_hero/config/install/language.content_settings.block_content.skeletor_hero.yml
+++ b/modules/custom/skeletor_hero/config/install/language.content_settings.block_content.skeletor_hero.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.skeletor_hero
+id: block_content.skeletor_hero
+target_entity_type_id: block_content
+target_bundle: skeletor_hero
+default_langcode: site_default
+language_alterable: false

--- a/modules/custom/skeletor_hero/config/install/paragraphs.paragraphs_type.component_hero.yml
+++ b/modules/custom/skeletor_hero/config/install/paragraphs.paragraphs_type.component_hero.yml
@@ -2,7 +2,7 @@ langcode: en
 status: true
 dependencies: {  }
 id: component_hero
-label: Hero
+label: 'Hero Component'
 icon_uuid: null
 description: 'Full Hero Component.'
 behavior_plugins: {  }

--- a/modules/custom/skeletor_hero/skeletor_hero.info.yml
+++ b/modules/custom/skeletor_hero/skeletor_hero.info.yml
@@ -3,8 +3,10 @@ description: 'Hero component for skeletor profile.'
 type: module
 core: 8.x
 dependencies:
+  - block_content
   - entity_reference_revisions
   - field
+  - language
   - link
   - paragraphs
 version: 8.x-1.0

--- a/modules/custom/skeletor_tabs_component/config/install/block_content.type.skeletor_tabs.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/block_content.type.skeletor_tabs.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: skeletor_tabs
+label: Tabs
+revision: 0
+description: 'Create tabs block using Skeletor tabs component.'

--- a/modules/custom/skeletor_tabs_component/config/install/core.entity_form_display.block_content.skeletor_tabs.default.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/core.entity_form_display.block_content.skeletor_tabs.default.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.skeletor_tabs
+    - field.field.block_content.skeletor_tabs.field_component_tabs
+  module:
+    - paragraphs
+id: block_content.skeletor_tabs.default
+targetEntityType: block_content
+bundle: skeletor_tabs
+mode: default
+content:
+  field_component_tabs:
+    type: entity_reference_paragraphs
+    weight: 27
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+    third_party_settings: {  }
+    region: content
+  info:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/custom/skeletor_tabs_component/config/install/core.entity_form_display.paragraph.component_tab.default.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/core.entity_form_display.paragraph.component_tab.default.yml
@@ -1,0 +1,42 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.component_tab.field_component_tab_content
+    - field.field.paragraph.component_tab.field_component_tab_title
+    - paragraphs.paragraphs_type.component_tab
+  module:
+    - paragraphs
+id: paragraph.component_tab.default
+targetEntityType: paragraph
+bundle: component_tab
+mode: default
+content:
+  field_component_tab_content:
+    type: entity_reference_paragraphs
+    weight: 1
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+    third_party_settings: {  }
+    region: content
+  field_component_tab_title:
+    type: entity_reference_paragraphs
+    weight: 0
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/modules/custom/skeletor_tabs_component/config/install/core.entity_form_display.paragraph.component_tab_content.default.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/core.entity_form_display.paragraph.component_tab_content.default.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.component_tab_content.field_tab_content_text
+    - paragraphs.paragraphs_type.component_tab_content
+  module:
+    - text
+id: paragraph.component_tab_content.default
+targetEntityType: paragraph
+bundle: component_tab_content
+mode: default
+content:
+  field_tab_content_text:
+    weight: 0
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/modules/custom/skeletor_tabs_component/config/install/core.entity_form_display.paragraph.component_tab_title.default.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/core.entity_form_display.paragraph.component_tab_title.default.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.component_tab_title.field_tab_title
+    - paragraphs.paragraphs_type.component_tab_title
+id: paragraph.component_tab_title.default
+targetEntityType: paragraph
+bundle: component_tab_title
+mode: default
+content:
+  field_tab_title:
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/modules/custom/skeletor_tabs_component/config/install/core.entity_form_display.paragraph.component_tabs.component_no_title.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/core.entity_form_display.paragraph.component_tabs.component_no_title.yml
@@ -1,0 +1,32 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.paragraph.component_no_title
+    - field.field.paragraph.component_tabs.field_component_tab
+    - field.field.paragraph.component_tabs.field_component_tabs_title
+    - paragraphs.paragraphs_type.component_tabs
+  module:
+    - paragraphs
+id: paragraph.component_tabs.component_no_title
+targetEntityType: paragraph
+bundle: component_tabs
+mode: component_no_title
+content:
+  field_component_tab:
+    type: entity_reference_paragraphs
+    weight: 0
+    settings:
+      title: Tab
+      title_plural: Tabs
+      edit_mode: open
+      add_mode: button
+      form_display_mode: default
+      default_paragraph_type: component_tab
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  field_component_tabs_title: true
+  status: true
+  uid: true

--- a/modules/custom/skeletor_tabs_component/config/install/core.entity_form_display.paragraph.component_tabs.default.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/core.entity_form_display.paragraph.component_tabs.default.yml
@@ -1,0 +1,42 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.component_tabs.field_component_tab
+    - field.field.paragraph.component_tabs.field_component_tabs_title
+    - paragraphs.paragraphs_type.component_tabs
+  module:
+    - paragraphs
+id: paragraph.component_tabs.default
+targetEntityType: paragraph
+bundle: component_tabs
+mode: default
+content:
+  field_component_tab:
+    type: entity_reference_paragraphs
+    weight: 1
+    settings:
+      title: Tab
+      title_plural: Tabs
+      edit_mode: open
+      add_mode: button
+      form_display_mode: default
+      default_paragraph_type: component_tab
+    third_party_settings: {  }
+    region: content
+  field_component_tabs_title:
+    type: entity_reference_paragraphs
+    weight: 0
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: button
+      form_display_mode: default
+      default_paragraph_type: _none
+    third_party_settings: {  }
+    region: content
+hidden:
+  created: true
+  status: true
+  uid: true

--- a/modules/custom/skeletor_tabs_component/config/install/core.entity_view_display.block_content.skeletor_tabs.default.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/core.entity_view_display.block_content.skeletor_tabs.default.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.skeletor_tabs
+    - field.field.block_content.skeletor_tabs.field_component_tabs
+  module:
+    - entity_reference_revisions
+id: block_content.skeletor_tabs.default
+targetEntityType: block_content
+bundle: skeletor_tabs
+mode: default
+content:
+  field_component_tabs:
+    type: entity_reference_revisions_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/modules/custom/skeletor_tabs_component/config/install/core.entity_view_display.paragraph.component_tab.default.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/core.entity_view_display.paragraph.component_tab.default.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.component_tab.field_component_tab_content
+    - field.field.paragraph.component_tab.field_component_tab_title
+    - paragraphs.paragraphs_type.component_tab
+  module:
+    - entity_reference_revisions
+id: paragraph.component_tab.default
+targetEntityType: paragraph
+bundle: component_tab
+mode: default
+content:
+  field_component_tab_content:
+    type: entity_reference_revisions_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_component_tab_title: true

--- a/modules/custom/skeletor_tabs_component/config/install/core.entity_view_display.paragraph.component_tab.tab_nav_link.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/core.entity_view_display.paragraph.component_tab.tab_nav_link.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.tab_nav_link
+    - field.field.paragraph.component_tab.field_component_tab_content
+    - field.field.paragraph.component_tab.field_component_tab_title
+    - paragraphs.paragraphs_type.component_tab
+  module:
+    - entity_reference_revisions
+id: paragraph.component_tab.tab_nav_link
+targetEntityType: paragraph
+bundle: component_tab
+mode: tab_nav_link
+content:
+  field_component_tab_title:
+    type: entity_reference_revisions_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_component_tab_content: true

--- a/modules/custom/skeletor_tabs_component/config/install/core.entity_view_display.paragraph.component_tab_content.default.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/core.entity_view_display.paragraph.component_tab_content.default.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.component_tab_content.field_tab_content_text
+    - paragraphs.paragraphs_type.component_tab_content
+  module:
+    - text
+id: paragraph.component_tab_content.default
+targetEntityType: paragraph
+bundle: component_tab_content
+mode: default
+content:
+  field_tab_content_text:
+    weight: 0
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+hidden: {  }

--- a/modules/custom/skeletor_tabs_component/config/install/core.entity_view_display.paragraph.component_tab_title.default.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/core.entity_view_display.paragraph.component_tab_title.default.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.component_tab_title.field_tab_title
+    - paragraphs.paragraphs_type.component_tab_title
+id: paragraph.component_tab_title.default
+targetEntityType: paragraph
+bundle: component_tab_title
+mode: default
+content:
+  field_tab_title:
+    weight: 0
+    label: hidden
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+hidden: {  }

--- a/modules/custom/skeletor_tabs_component/config/install/core.entity_view_display.paragraph.component_tabs.component_no_title.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/core.entity_view_display.paragraph.component_tabs.component_no_title.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.component_no_title
+    - field.field.paragraph.component_tabs.field_component_tab
+    - field.field.paragraph.component_tabs.field_component_tabs_title
+    - paragraphs.paragraphs_type.component_tabs
+  module:
+    - entity_reference_revisions
+id: paragraph.component_tabs.component_no_title
+targetEntityType: paragraph
+bundle: component_tabs
+mode: component_no_title
+content:
+  field_component_tab:
+    type: entity_reference_revisions_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_component_tabs_title: true

--- a/modules/custom/skeletor_tabs_component/config/install/core.entity_view_display.paragraph.component_tabs.default.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/core.entity_view_display.paragraph.component_tabs.default.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.paragraph.component_tabs.field_component_tab
+    - field.field.paragraph.component_tabs.field_component_tabs_title
+    - paragraphs.paragraphs_type.component_tabs
+  module:
+    - entity_reference_revisions
+id: paragraph.component_tabs.default
+targetEntityType: paragraph
+bundle: component_tabs
+mode: default
+content:
+  field_component_tab:
+    type: entity_reference_revisions_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+  field_component_tabs_title:
+    type: entity_reference_revisions_entity_view
+    weight: 0
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+hidden: {  }

--- a/modules/custom/skeletor_tabs_component/config/install/core.entity_view_mode.paragraph.tab_nav_link.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/core.entity_view_mode.paragraph.tab_nav_link.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.tab_nav_link
+label: 'Tab Nav Link'
+targetEntityType: paragraph
+cache: true

--- a/modules/custom/skeletor_tabs_component/config/install/field.field.block_content.skeletor_tabs.field_component_tabs.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/field.field.block_content.skeletor_tabs.field_component_tabs.yml
@@ -1,0 +1,60 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.skeletor_tabs
+    - field.storage.block_content.field_component_tabs
+    - paragraphs.paragraphs_type.component_tabs
+  module:
+    - entity_reference_revisions
+id: block_content.skeletor_tabs.field_component_tabs
+field_name: field_component_tabs
+entity_type: block_content
+bundle: skeletor_tabs
+label: Tabs
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      component_tabs: component_tabs
+    target_bundles_drag_drop:
+      component_accordion:
+        weight: 12
+        enabled: false
+      component_accordion_item:
+        weight: 13
+        enabled: false
+      component_accordion_item_content:
+        weight: 14
+        enabled: false
+      component_hero:
+        weight: 15
+        enabled: false
+      component_hero_text:
+        weight: 16
+        enabled: false
+      component_tab:
+        weight: 17
+        enabled: false
+      component_tab_content:
+        weight: 18
+        enabled: false
+      component_tab_title:
+        weight: 19
+        enabled: false
+      component_tabs:
+        enabled: true
+        weight: 20
+      component_text:
+        weight: 21
+        enabled: false
+      component_title:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/modules/custom/skeletor_tabs_component/config/install/field.field.paragraph.component_tab.field_component_tab_content.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/field.field.paragraph.component_tab.field_component_tab_content.yml
@@ -1,0 +1,60 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_component_tab_content
+    - paragraphs.paragraphs_type.component_tab
+    - paragraphs.paragraphs_type.component_tab_content
+  module:
+    - entity_reference_revisions
+id: paragraph.component_tab.field_component_tab_content
+field_name: field_component_tab_content
+entity_type: paragraph
+bundle: component_tab
+label: 'Tab Content'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      component_tab_content: component_tab_content
+    target_bundles_drag_drop:
+      component_accordion:
+        weight: 12
+        enabled: false
+      component_accordion_item:
+        weight: 13
+        enabled: false
+      component_accordion_item_content:
+        weight: 14
+        enabled: false
+      component_hero:
+        weight: 15
+        enabled: false
+      component_hero_text:
+        weight: 16
+        enabled: false
+      component_tab:
+        weight: 17
+        enabled: false
+      component_tab_content:
+        enabled: true
+        weight: 18
+      component_tab_title:
+        weight: 19
+        enabled: false
+      component_tabs:
+        weight: 20
+        enabled: false
+      component_text:
+        weight: 21
+        enabled: false
+      component_title:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/modules/custom/skeletor_tabs_component/config/install/field.field.paragraph.component_tab.field_component_tab_title.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/field.field.paragraph.component_tab.field_component_tab_title.yml
@@ -1,0 +1,60 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_component_tab_title
+    - paragraphs.paragraphs_type.component_tab
+    - paragraphs.paragraphs_type.component_tab_title
+  module:
+    - entity_reference_revisions
+id: paragraph.component_tab.field_component_tab_title
+field_name: field_component_tab_title
+entity_type: paragraph
+bundle: component_tab
+label: 'Tab Title'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      component_tab_title: component_tab_title
+    target_bundles_drag_drop:
+      component_accordion:
+        weight: 12
+        enabled: false
+      component_accordion_item:
+        weight: 13
+        enabled: false
+      component_accordion_item_content:
+        weight: 14
+        enabled: false
+      component_hero:
+        weight: 15
+        enabled: false
+      component_hero_text:
+        weight: 16
+        enabled: false
+      component_tab:
+        weight: 17
+        enabled: false
+      component_tab_content:
+        weight: 18
+        enabled: false
+      component_tab_title:
+        enabled: true
+        weight: 19
+      component_tabs:
+        weight: 20
+        enabled: false
+      component_text:
+        weight: 21
+        enabled: false
+      component_title:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/modules/custom/skeletor_tabs_component/config/install/field.field.paragraph.component_tab_content.field_tab_content_text.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/field.field.paragraph.component_tab_content.field_tab_content_text.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_tab_content_text
+    - paragraphs.paragraphs_type.component_tab_content
+  module:
+    - text
+id: paragraph.component_tab_content.field_tab_content_text
+field_name: field_tab_content_text
+entity_type: paragraph
+bundle: component_tab_content
+label: Text
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/modules/custom/skeletor_tabs_component/config/install/field.field.paragraph.component_tab_title.field_tab_title.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/field.field.paragraph.component_tab_title.field_tab_title.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_tab_title
+    - paragraphs.paragraphs_type.component_tab_title
+id: paragraph.component_tab_title.field_tab_title
+field_name: field_tab_title
+entity_type: paragraph
+bundle: component_tab_title
+label: 'Tab Title'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/custom/skeletor_tabs_component/config/install/field.field.paragraph.component_tabs.field_component_tab.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/field.field.paragraph.component_tabs.field_component_tab.yml
@@ -1,0 +1,60 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_component_tab
+    - paragraphs.paragraphs_type.component_tab
+    - paragraphs.paragraphs_type.component_tabs
+  module:
+    - entity_reference_revisions
+id: paragraph.component_tabs.field_component_tab
+field_name: field_component_tab
+entity_type: paragraph
+bundle: component_tabs
+label: Tab
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      component_tab: component_tab
+    target_bundles_drag_drop:
+      component_accordion:
+        weight: 12
+        enabled: false
+      component_accordion_item:
+        weight: 13
+        enabled: false
+      component_accordion_item_content:
+        weight: 14
+        enabled: false
+      component_hero:
+        weight: 15
+        enabled: false
+      component_hero_text:
+        weight: 16
+        enabled: false
+      component_tab:
+        enabled: true
+        weight: 17
+      component_tab_content:
+        weight: 18
+        enabled: false
+      component_tab_title:
+        weight: 19
+        enabled: false
+      component_tabs:
+        weight: 20
+        enabled: false
+      component_text:
+        weight: 21
+        enabled: false
+      component_title:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/modules/custom/skeletor_tabs_component/config/install/field.field.paragraph.component_tabs.field_component_tabs_title.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/field.field.paragraph.component_tabs.field_component_tabs_title.yml
@@ -1,0 +1,60 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_component_tabs_title
+    - paragraphs.paragraphs_type.component_tabs
+    - paragraphs.paragraphs_type.component_title
+  module:
+    - entity_reference_revisions
+id: paragraph.component_tabs.field_component_tabs_title
+field_name: field_component_tabs_title
+entity_type: paragraph
+bundle: component_tabs
+label: 'Component Title'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      component_title: component_title
+    target_bundles_drag_drop:
+      component_accordion:
+        weight: 9
+        enabled: false
+      component_accordion_item:
+        weight: 10
+        enabled: false
+      component_accordion_item_content:
+        weight: 11
+        enabled: false
+      component_hero:
+        weight: 12
+        enabled: false
+      component_hero_text:
+        weight: 13
+        enabled: false
+      component_tabs:
+        weight: 14
+        enabled: false
+      component_text:
+        weight: 15
+        enabled: false
+      component_title:
+        enabled: true
+        weight: 16
+      component_tab:
+        weight: 17
+        enabled: false
+      component_tab_content:
+        weight: 18
+        enabled: false
+      component_tab_title:
+        weight: 19
+        enabled: false
+field_type: entity_reference_revisions

--- a/modules/custom/skeletor_tabs_component/config/install/field.storage.block_content.field_component_tabs.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/field.storage.block_content.field_component_tabs.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - entity_reference_revisions
+    - paragraphs
+id: block_content.field_component_tabs
+field_name: field_component_tabs
+entity_type: block_content
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/skeletor_tabs_component/config/install/field.storage.paragraph.field_component_tab.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/field.storage.paragraph.field_component_tab.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_component_tab
+field_name: field_component_tab
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/skeletor_tabs_component/config/install/field.storage.paragraph.field_component_tab_content.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/field.storage.paragraph.field_component_tab_content.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_component_tab_content
+field_name: field_component_tab_content
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/skeletor_tabs_component/config/install/field.storage.paragraph.field_component_tab_title.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/field.storage.paragraph.field_component_tab_title.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_component_tab_title
+field_name: field_component_tab_title
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/skeletor_tabs_component/config/install/field.storage.paragraph.field_component_tabs_title.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/field.storage.paragraph.field_component_tabs_title.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - paragraphs
+id: paragraph.field_component_tabs_title
+field_name: field_component_tabs_title
+entity_type: paragraph
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/skeletor_tabs_component/config/install/field.storage.paragraph.field_tab_content_text.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/field.storage.paragraph.field_tab_content_text.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+    - text
+id: paragraph.field_tab_content_text
+field_name: field_tab_content_text
+entity_type: paragraph
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/skeletor_tabs_component/config/install/field.storage.paragraph.field_tab_title.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/field.storage.paragraph.field_tab_title.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.field_tab_title
+field_name: field_tab_title
+entity_type: paragraph
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/skeletor_tabs_component/config/install/language.content_settings.block_content.skeletor_tabs.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/language.content_settings.block_content.skeletor_tabs.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.skeletor_tabs
+id: block_content.skeletor_tabs
+target_entity_type_id: block_content
+target_bundle: skeletor_tabs
+default_langcode: site_default
+language_alterable: false

--- a/modules/custom/skeletor_tabs_component/config/install/paragraphs.paragraphs_type.component_tab.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/paragraphs.paragraphs_type.component_tab.yml
@@ -1,8 +1,8 @@
 langcode: en
 status: true
 dependencies: {  }
-id: component_text
-label: 'Text Component'
+id: component_tab
+label: Tab
 icon_uuid: null
-description: 'Basic text component. '
+description: 'Individual tab for tabs component.'
 behavior_plugins: {  }

--- a/modules/custom/skeletor_tabs_component/config/install/paragraphs.paragraphs_type.component_tab_content.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/paragraphs.paragraphs_type.component_tab_content.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: component_tab_content
+label: 'Tab Content'
+icon_uuid: null
+description: 'Container for content inside individual tab.'
+behavior_plugins: {  }

--- a/modules/custom/skeletor_tabs_component/config/install/paragraphs.paragraphs_type.component_tab_title.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/paragraphs.paragraphs_type.component_tab_title.yml
@@ -1,8 +1,8 @@
 langcode: en
 status: true
 dependencies: {  }
-id: component_text
-label: 'Text Component'
+id: component_tab_title
+label: 'Tab Title'
 icon_uuid: null
-description: 'Basic text component. '
+description: 'Title for individual tab'
 behavior_plugins: {  }

--- a/modules/custom/skeletor_tabs_component/config/install/paragraphs.paragraphs_type.component_tabs.yml
+++ b/modules/custom/skeletor_tabs_component/config/install/paragraphs.paragraphs_type.component_tabs.yml
@@ -1,0 +1,8 @@
+langcode: en
+status: true
+dependencies: {  }
+id: component_tabs
+label: 'Tabs Component'
+icon_uuid: null
+description: 'Tabs component (becomes accordion on mobile)'
+behavior_plugins: {  }

--- a/modules/custom/skeletor_tabs_component/skeletor_tabs_component.features.yml
+++ b/modules/custom/skeletor_tabs_component/skeletor_tabs_component.features.yml
@@ -1,0 +1,2 @@
+bundle: skeletor
+required: true

--- a/modules/custom/skeletor_tabs_component/skeletor_tabs_component.info.yml
+++ b/modules/custom/skeletor_tabs_component/skeletor_tabs_component.info.yml
@@ -1,5 +1,5 @@
-name: 'Skeletor Text Component'
-description: 'Basic text component for Skeletor.'
+name: 'Skeletor Tabs Component'
+description: 'Tabs component for skeletor profile.'
 type: module
 core: 8.x
 dependencies:

--- a/modules/custom/skeletor_text_component/config/install/block_content.type.skeletor_text.yml
+++ b/modules/custom/skeletor_text_component/config/install/block_content.type.skeletor_text.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+id: skeletor_text
+label: Text
+revision: 0
+description: 'Create text block using Skeletor text component.'

--- a/modules/custom/skeletor_text_component/config/install/core.entity_form_display.block_content.skeletor_text.default.yml
+++ b/modules/custom/skeletor_text_component/config/install/core.entity_form_display.block_content.skeletor_text.default.yml
@@ -1,0 +1,41 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.skeletor_text
+    - field.field.block_content.skeletor_text.field_component_text
+  module:
+    - paragraphs
+id: block_content.skeletor_text.default
+targetEntityType: block_content
+bundle: skeletor_text
+mode: default
+content:
+  field_component_text:
+    type: entity_reference_paragraphs
+    weight: 27
+    settings:
+      title: Paragraph
+      title_plural: Paragraphs
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+      default_paragraph_type: ''
+    third_party_settings: {  }
+    region: content
+  info:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/custom/skeletor_text_component/config/install/core.entity_form_display.paragraph.component_text.component_no_title.yml
+++ b/modules/custom/skeletor_text_component/config/install/core.entity_form_display.paragraph.component_text.component_no_title.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_form_mode.paragraph.component_no_title
+    - field.field.paragraph.component_text.field_component_text_title
+    - field.field.paragraph.component_text.field_component_textarea
+    - paragraphs.paragraphs_type.component_text
+  module:
+    - text
+id: paragraph.component_text.component_no_title
+targetEntityType: paragraph
+bundle: component_text
+mode: component_no_title
+content:
+  field_component_textarea:
+    weight: 0
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+hidden:
+  created: true
+  field_component_text_title: true
+  status: true
+  uid: true

--- a/modules/custom/skeletor_text_component/config/install/core.entity_view_display.block_content.skeletor_text.default.yml
+++ b/modules/custom/skeletor_text_component/config/install/core.entity_view_display.block_content.skeletor_text.default.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.skeletor_text
+    - field.field.block_content.skeletor_text.field_component_text
+  module:
+    - entity_reference_revisions
+id: block_content.skeletor_text.default
+targetEntityType: block_content
+bundle: skeletor_text
+mode: default
+content:
+  field_component_text:
+    type: entity_reference_revisions_entity_view
+    weight: 1
+    label: hidden
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/modules/custom/skeletor_text_component/config/install/core.entity_view_display.paragraph.component_text.component_no_title.yml
+++ b/modules/custom/skeletor_text_component/config/install/core.entity_view_display.paragraph.component_text.component_no_title.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.paragraph.component_no_title
+    - field.field.paragraph.component_text.field_component_text_title
+    - field.field.paragraph.component_text.field_component_textarea
+    - paragraphs.paragraphs_type.component_text
+  module:
+    - text
+id: paragraph.component_text.component_no_title
+targetEntityType: paragraph
+bundle: component_text
+mode: component_no_title
+content:
+  field_component_textarea:
+    type: text_default
+    weight: 0
+    region: content
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+hidden:
+  field_component_text_title: true

--- a/modules/custom/skeletor_text_component/config/install/field.field.block_content.skeletor_text.field_component_text.yml
+++ b/modules/custom/skeletor_text_component/config/install/field.field.block_content.skeletor_text.field_component_text.yml
@@ -1,0 +1,60 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.skeletor_text
+    - field.storage.block_content.field_component_text
+    - paragraphs.paragraphs_type.component_text
+  module:
+    - entity_reference_revisions
+id: block_content.skeletor_text.field_component_text
+field_name: field_component_text
+entity_type: block_content
+bundle: skeletor_text
+label: 'Component Text'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    negate: 0
+    target_bundles:
+      component_text: component_text
+    target_bundles_drag_drop:
+      component_accordion:
+        weight: 12
+        enabled: false
+      component_accordion_item:
+        weight: 13
+        enabled: false
+      component_accordion_item_content:
+        weight: 14
+        enabled: false
+      component_hero:
+        weight: 15
+        enabled: false
+      component_hero_text:
+        weight: 16
+        enabled: false
+      component_tab:
+        weight: 17
+        enabled: false
+      component_tab_content:
+        weight: 18
+        enabled: false
+      component_tab_title:
+        weight: 19
+        enabled: false
+      component_tabs:
+        weight: 20
+        enabled: false
+      component_text:
+        enabled: true
+        weight: 21
+      component_title:
+        weight: 22
+        enabled: false
+field_type: entity_reference_revisions

--- a/modules/custom/skeletor_text_component/config/install/field.storage.block_content.field_component_text.yml
+++ b/modules/custom/skeletor_text_component/config/install/field.storage.block_content.field_component_text.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - block_content
+    - entity_reference_revisions
+    - paragraphs
+id: block_content.field_component_text
+field_name: field_component_text
+entity_type: block_content
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/custom/skeletor_text_component/config/install/language.content_settings.block_content.skeletor_text.yml
+++ b/modules/custom/skeletor_text_component/config/install/language.content_settings.block_content.skeletor_text.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - block_content.type.skeletor_text
+id: block_content.skeletor_text
+target_entity_type_id: block_content
+target_bundle: skeletor_text
+default_langcode: site_default
+language_alterable: false

--- a/modules/custom/skeletor_title_component/config/install/core.entity_form_mode.paragraph.component_no_title.yml
+++ b/modules/custom/skeletor_title_component/config/install/core.entity_form_mode.paragraph.component_no_title.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.component_no_title
+label: 'No Title'
+targetEntityType: paragraph
+cache: true

--- a/modules/custom/skeletor_title_component/config/install/core.entity_view_mode.paragraph.component_no_title.yml
+++ b/modules/custom/skeletor_title_component/config/install/core.entity_view_mode.paragraph.component_no_title.yml
@@ -1,0 +1,9 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - paragraphs
+id: paragraph.component_no_title
+label: 'No Title'
+targetEntityType: paragraph
+cache: true

--- a/themes/custom/barebones_bootstrap_STARTERKIT/includes/field.inc
+++ b/themes/custom/barebones_bootstrap_STARTERKIT/includes/field.inc
@@ -10,7 +10,19 @@ use \Drupal\Component\Utility\Html;
 function barebones_bootstrap_STARTERKIT_preprocess_field(array &$variables) {
   $field_name = $variables['element']['#field_name'];
 
+  // Add unique ID in case a page has multiple accordion components.
   if ($field_name == 'field_accordion_items') {
     $variables['accordion_id'] = Html::getUniqueID('accordion');
+  }
+
+  // Add unique ID in case a page has multiple tab components..
+  if ($field_name == 'field_component_tab') {
+    $variables['tab_id'] = Html::getUniqueID('tab-accordion');
+
+    // Use different mode for the tab/accordion title.
+    foreach ($variables['items'] as &$item) {
+      $item['tab_nav_link'] = $item['content'];
+      $item['tab_nav_link']['#view_mode'] = 'tab_nav_link';
+    }
   }
 }

--- a/themes/custom/barebones_bootstrap_STARTERKIT/src/css/app.scss
+++ b/themes/custom/barebones_bootstrap_STARTERKIT/src/css/app.scss
@@ -1,4 +1,8 @@
 // the ~ allows you to reference things in node_modules
 
+// Base Import.
 @import "base/bootstrap";
 @import "base/helpers";
+
+// Components Import.
+@import "components/tabs";

--- a/themes/custom/barebones_bootstrap_STARTERKIT/src/css/components/_tabs.scss
+++ b/themes/custom/barebones_bootstrap_STARTERKIT/src/css/components/_tabs.scss
@@ -1,0 +1,16 @@
+// Styles for Skeletor Tabs/Accordion component.
+// -----------------------------------------------------------------------------
+
+.tabs-accordion__content > .tab-pane {
+  // sass-lint:disable-block no-important
+  @include media-breakpoint-down(sm) {
+    display: block !important;
+    opacity: 1 !important;
+  }
+}
+
+.tabs-accordion__content > .card {
+  @include media-breakpoint-up(md) {
+    border: 0 none;
+  }
+}

--- a/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/field--field-component-tab-content.html.twig
+++ b/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/field--field-component-tab-content.html.twig
@@ -1,0 +1,1 @@
+{% extends '@barebones_bootstrap_STARTERKIT/patterns/field-reset.html.twig' %}

--- a/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/field--field-component-tab-title.html.twig
+++ b/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/field--field-component-tab-title.html.twig
@@ -1,0 +1,1 @@
+{% extends '@barebones_bootstrap_STARTERKIT/patterns/field-reset.html.twig' %}

--- a/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/field--field-component-tab.html.twig
+++ b/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/field--field-component-tab.html.twig
@@ -1,0 +1,71 @@
+{#
+/**
+ * @file
+ * Skeletor tabs/accordion template file.
+ *
+ */
+#}
+{%
+  set classes = [
+  'field',
+  'field--name-' ~ field_name|clean_class,
+  'field--type-' ~ field_type|clean_class,
+  'field--label-' ~ label_display,
+  'tabs-accordion',
+  ]
+%}
+
+<div{{ attributes.addClass(classes) }}>
+  <nav role="naviation" class="tabs-accordion__nav d-none d-md-block">
+    <div class="nav nav-tabs" id="nav-{{ tab_id }}" role="tablist">
+      {% for item in items %}
+        {% if loop.first %}
+          <a class="nav-item nav-link active" id="nav-{{ tab_id }}-{{ loop.index }}" data-toggle="tab" href="#pane-{{ tab_id }}-{{ loop.index }}" role="tab" aria-controls="pane-{{ tab_id }}-{{ loop.index }}" aria-selected="true">
+            {{ item.tab_nav_link }}
+          </a>
+        {% else %}
+          <a class="nav-item nav-link" id="nav-{{ tab_id }}-{{ loop.index }}" data-toggle="tab" href="#pane-{{ tab_id }}-{{ loop.index }}" role="tab" aria-controls="pane-{{ tab_id }}-{{ loop.index }}" aria-selected="false">
+            {{ item.tab_nav_link }}
+          </a>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </nav>
+
+  <div class="tab-content tabs-accordion__content" id="content-{{ tab_id }}">
+    {% for item in items %}
+      {% if loop.first %}
+        <div class="tabs-accordion__pane card tab-pane fade show active" id="pane-{{ tab_id }}-{{ loop.index }}" role="tabpanel" aria-labelledby="nav-{{ tab_id }}-{{ loop.index }}">
+          <div class="card-header d-md-none" role="tab" id="card-heading-{{ tab_id }}-{{ loop.index }}">
+            <h3 class="mb-0">
+              <a data-toggle="collapse" href="#card-body-{{ tab_id }}-{{ loop.index }}" data-parent="#content-{{ tab_id }}" aria-expanded="true" aria-controls="card-body-{{ tab_id }}-{{ loop.index }}">
+                {{ item.tab_nav_link }}
+              </a>
+            </h3>
+          </div>
+          <div id="card-body-{{ tab_id }}-{{ loop.index }}" class="collapse show d-md-block" role="tabpanel" aria-labelledby="card-heading-{{ tab_id }}-{{ loop.index }}">
+            <div class="card-body">
+              {{ item.content }}
+            </div>
+          </div>
+        </div>
+      {% else %}
+        <div class="tabs-accordion__pane card tab-pane fade" id="pane-{{ tab_id }}-{{ loop.index }}" role="tabpanel" aria-labelledby="nav-{{ tab_id }}-{{ loop.index }}">
+          <div class="card-header d-md-none" role="tab" id="card-heading-{{ tab_id }}-{{ loop.index }}">
+            <h3 class="mb-0">
+              <a class="collapsed" data-toggle="collapse" href="#card-body-{{ tab_id }}-{{ loop.index }}" data-parent="#content-{{ tab_id }}" aria-expanded="false" aria-controls="card-body-{{ tab_id }}-{{ loop.index }}">
+                {{ item.tab_nav_link }}
+              </a>
+            </h3>
+          </div>
+          <div id="card-body-{{ tab_id }}-{{ loop.index }}" class="collapse d-md-block" role="tabpanel" aria-labelledby="card-heading-{{ tab_id }}-{{ loop.index }}">
+            <div class="card-body">
+              {{ item.content }}
+            </div>
+          </div>
+        </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+
+</div>

--- a/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/field--field-component-tabs-title.html.twig
+++ b/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/field--field-component-tabs-title.html.twig
@@ -1,0 +1,1 @@
+{% extends '@barebones_bootstrap_STARTERKIT/patterns/field-reset.html.twig' %}

--- a/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/field--field-tab-title.html.twig
+++ b/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/field--field-tab-title.html.twig
@@ -1,0 +1,1 @@
+{% extends '@barebones_bootstrap_STARTERKIT/patterns/field-reset.html.twig' %}

--- a/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/paragraph--component-tab-content.html.twig
+++ b/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/paragraph--component-tab-content.html.twig
@@ -1,0 +1,1 @@
+{% extends '@barebones_bootstrap_STARTERKIT/patterns/paragraph-reset.html.twig' %}

--- a/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/paragraph--component-tab-title.html.twig
+++ b/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/paragraph--component-tab-title.html.twig
@@ -1,0 +1,1 @@
+{% extends '@barebones_bootstrap_STARTERKIT/patterns/paragraph-reset.html.twig' %}

--- a/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/paragraph--component-tab.html.twig
+++ b/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/paragraph--component-tab.html.twig
@@ -1,0 +1,1 @@
+{% extends '@barebones_bootstrap_STARTERKIT/patterns/paragraph-reset.html.twig' %}

--- a/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/paragraph--component-tabs.html.twig
+++ b/themes/custom/barebones_bootstrap_STARTERKIT/templates/components/tabs/paragraph--component-tabs.html.twig
@@ -1,0 +1,57 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a paragraph.
+ *
+ * Available variables:
+ * - paragraph: Full paragraph entity.
+ *   Only method names starting with "get", "has", or "is" and a few common
+ *   methods such as "id", "label", and "bundle" are available. For example:
+ *   - paragraph.getCreatedTime() will return the paragraph creation timestamp.
+ *   - paragraph.id(): The paragraph ID.
+ *   - paragraph.bundle(): The type of the paragraph, for example, "image" or "text".
+ *   - paragraph.getOwnerId(): The user ID of the paragraph author.
+ *   See Drupal\paragraphs\Entity\Paragraph for a full list of public properties
+ *   and methods for the paragraph object.
+ * - content: All paragraph items. Use {{ content }} to print them all,
+ *   or print a subset such as {{ content.field_example }}. Use
+ *   {{ content|without('field_example') }} to temporarily suppress the printing
+ *   of a given child element.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class element may contain one or more of the following
+ *   classes:
+ *   - paragraphs: The current template type (also known as a "theming hook").
+ *   - paragraphs--type-[type]: The current paragraphs type. For example, if the paragraph is an
+ *     "Image" it would result in "paragraphs--type--image". Note that the machine
+ *     name will often be in a short form of the human readable label.
+ *   - paragraphs--view-mode--[view_mode]: The View Mode of the paragraph; for example, a
+ *     preview would result in: "paragraphs--view-mode--preview", and
+ *     default: "paragraphs--view-mode--default".
+ * - view_mode: View mode; for example, "preview" or "full".
+ * - logged_in: Flag for authenticated user status. Will be true when the
+ *   current user is a logged-in member.
+ * - is_admin: Flag for admin user status. Will be true when the current user
+ *   is an administrator.
+ *
+ * @see template_preprocess_paragraph()
+ *
+ * @ingroup themeable
+ */
+#}
+{%
+  set classes = [
+    'paragraph',
+    'paragraph--type--' ~ paragraph.bundle|clean_class,
+    view_mode ? 'paragraph--view-mode--' ~ view_mode|clean_class,
+    not paragraph.isPublished() ? 'paragraph--unpublished',
+    'component',
+    'component--tabs',
+  ]
+%}
+{% block paragraph %}
+  <section{{ attributes.addClass(classes) }}>
+    {% block content %}
+      {{ content }}
+    {% endblock %}
+  </section>
+{% endblock paragraph %}


### PR DESCRIPTION
### Testing Notes
#### Tabs component on node
* Checkout branch
* Enable Skeletor Tabs component module
* Create a content type if you don't already have one, and then add a paragraph entity revisions field and select the tabs component.
* Create a node with the tabs component, making sure to add more than one tab
* Save node
* Reduce the width of your browser to less than 768px wide. The tabs should now be converted to an accordion.

#### Custom blocks type
* Checkout branch
* If you have the features module, you may want to revert the Skeletor Component modules (``/admin/config/development/features``)
* Create/place a custom block for each of the custom block types available and make sure that the tabs and accordion blocks work properly. 

