### PR TITLE
Build all branches on source repo

### DIFF
--- a/project-scaffold/.travis.yml
+++ b/project-scaffold/.travis.yml
@@ -26,7 +26,6 @@ env:
     # The Acquia git repository to deploy built commits to.
     - DEPLOY_REPO=skeletor@svn-NNNN.devcloud.hosting.acquia.com:skeletor.git
     - DEPLOY_DEST=$HOME/skeletor
-    - DEPLOY_BRANCH=develop
 services:
   - memcached
   - mysql

--- a/project-scaffold/.travis.yml
+++ b/project-scaffold/.travis.yml
@@ -11,8 +11,8 @@ cache:
     - $HOME/.composer
     - $HOME/.drush/cache
 branches:
-  only:
-    - 8.2.x
+  except:
+    - /^[A-Z]{3,}-.*$/
 env:
   global:
     # The Acquia site name, as used in drush aliases.

--- a/project-scaffold/travis/deploy.sh
+++ b/project-scaffold/travis/deploy.sh
@@ -22,7 +22,7 @@ mkdir $DEPLOY_DEST
 echo "::Cloning out ${DEPLOY_REPO} into ${DEPLOY_DEST}"
 git clone $DEPLOY_REPO $DEPLOY_DEST
 cd $DEPLOY_DEST
-git checkout $DEPLOY_BRANCH
+git checkout build-${TRAVIS_BRANCH}
 
 # Create a travis-build branch off of our test commit since we're in a detached state.
 cd $PROJECT_ROOT
@@ -47,4 +47,4 @@ git add --all .
 git commit -m "${PULL_REQUEST_MESSAGE}
 
 Commit ${TRAVIS_COMMIT}"
-git push origin $DEPLOY_BRANCH
+git push origin build-${TRAVIS_BRANCH}

--- a/project-scaffold/travis/deploy.sh
+++ b/project-scaffold/travis/deploy.sh
@@ -22,7 +22,17 @@ mkdir $DEPLOY_DEST
 echo "::Cloning out ${DEPLOY_REPO} into ${DEPLOY_DEST}"
 git clone $DEPLOY_REPO $DEPLOY_DEST
 cd $DEPLOY_DEST
-git checkout build-${TRAVIS_BRANCH}
+
+if git rev-parse --verify origin/build-${TRAVIS_BRANCH}
+then
+  # Checkout the existing deploy branch.
+  echo "::Checking out existing branch build-${TRAVIS_BRANCH}"
+  git checkout build-${TRAVIS_BRANCH}
+else
+  # Create a new branch with empty history
+  echo "::Creating new branch build-${TRAVIS_BRANCH}"
+  git checkout --orphan build-${TRAVIS_BRANCH}
+fi
 
 # Create a travis-build branch off of our test commit since we're in a detached state.
 cd $PROJECT_ROOT


### PR DESCRIPTION
I haven't tested yet, but my understanding is that without adding only a single branch to build in `branches.only`, pushing multiple branches will overwrite a single deploy branch.

This change:
 - Allows independently building multiple branches, which would allow more easily testing changes on a dev environment.
 - Indicates via the branch name that it is a build artifact