### PR TITLE
Use project's version of drush in Acquia hooks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,8 @@
     "squizlabs/php_codesniffer": "^2.9"
   },
   "conflict": {
-    "drupal/drupal": "*"
+    "drupal/drupal": "*",
+    "drush/drush": "<9.0"
   },
   "minimum-stability": "dev",
   "prefer-stable": true,

--- a/project-scaffold/hooks/common/post-code-deploy/drush-import-up-rebuild.sh
+++ b/project-scaffold/hooks/common/post-code-deploy/drush-import-up-rebuild.sh
@@ -10,9 +10,11 @@ deployed_tag=$4
 repo_url=$5
 repo_type=$6
 
-drush_alias=$site'.'$target_env
+drush_alias=${site}'.'${site}'.'${target_env}
 
-drush @$drush_alias -y updatedb
-#drush @$drush_alias -y entity-updates
-drush @$drush_alias -y config-import sync
-#drush @$drush_alias twig-compile
+# Show commands being executed in the log.
+set -x
+
+/var/www/html/${site}.${target_env}/vendor/bin/drush @${drush_alias} updb -y
+/var/www/html/${site}.${target_env}/vendor/bin/drush @${drush_alias} cim vcs -y
+/var/www/html/${site}.${target_env}/vendor/bin/drush @${drush_alias} cr

--- a/project-scaffold/hooks/common/post-code-update/drush-import-up-rebuild.sh
+++ b/project-scaffold/hooks/common/post-code-update/drush-import-up-rebuild.sh
@@ -10,9 +10,11 @@ deployed_tag=$4
 repo_url=$5
 repo_type=$6
 
-drush_alias=$site'.'$target_env
+drush_alias=${site}'.'${site}'.'${target_env}
 
-drush @$drush_alias -y updatedb
-#drush @$drush_alias -y entity-updates
-drush @$drush_alias -y config-import sync
-#drush @$drush_alias twig-compile
+# Show commands being executed in the log.
+set -x
+
+/var/www/html/${site}.${target_env}/vendor/bin/drush @${drush_alias} updb -y
+/var/www/html/${site}.${target_env}/vendor/bin/drush @${drush_alias} cim vcs -y
+/var/www/html/${site}.${target_env}/vendor/bin/drush @${drush_alias} cr


### PR DESCRIPTION
Acquia still defaults to using Drush 8 (`drush`), and its global version of Drush 9 (`drush9`) is likely to differ from the project version and quite possibly outdated as well. (e.g. currently it is 9.4.0 instead of the latest 9.5.2).  Using drush when ssh-ed into an environment defers to the project version of drush (at least when working within the project directory).

This changes the hook scripts to use the project version of Drush instead of a global version.
In Drush 9, the format for defining aliases changed, and the format for calling aliases differs between local aliases (`@project.env`) and global aliases (`@provider.project.env`, though on acquia environments it's really `@project.project.env`)