### PR TITLE
Remove search_api dependencies which are now specified by acquia_conn…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,6 @@
     "drupal/media_entity_browser": "^2.0-alpha1",
     "drupal/image_widget_crop": "^2.2",
     "drupal/focal_point": "^1.0@beta",
-    "drupal/search_api": "^1.8",
-    "drupal/search_api_solr": "^2.0",
     "drupal/acquia_connector": "^1.16",
     "drupal/purge": "3.0-beta8",
     "drupal/acquia_purge": "1.0-beta3",


### PR DESCRIPTION
…ector

Acquia Connector requires search_api_solr 1.x, so the current `^2.0` restriction prevents a site from being able to use Acquia Search.