### PR TITLE
Remove hook_install

### DIFF
--- a/skeletor.install
+++ b/skeletor.install
@@ -4,16 +4,3 @@
  * @file
  * Install, update and uninstall functions for the Skeletor install profile.
  */
-
-/**
- * Implements hook_install().
- *
- * Perform actions to set up the site for this profile.
- *
- * @see system_install()
- */
-function skeletor_install() {
-  // First, do everything in standard profile.
-  include_once DRUPAL_ROOT . '/core/profiles/standard/standard.install';
-  standard_install();
-}


### PR DESCRIPTION
Installing from existing config doesn't work if profile has hook_install,
and skeletor doesn't otherwise inherit from standard, so existing hook
doesn't make sense.

https://www.drupal.org/node/2897299