### PR TITLE
Remove dev dependencies in deploy repository

### DIFF
--- a/project-scaffold/travis/deploy.sh
+++ b/project-scaffold/travis/deploy.sh
@@ -32,6 +32,11 @@ rsync -a $PROJECT_ROOT/ $DEPLOY_DEST --exclude .git --delete
 
 cd $DEPLOY_DEST
 
+echo -e 'travis_fold:start:composer-install-prod\\r'
+echo  "::Installing production composer dependencies"
+composer install --no-dev --no-suggest --optimize-autoloader
+echo -e 'travis_fold:end:composer-install-prod\\r'
+
 # Change webroot from web/ to docroot/ for Acquia if necessary.
 if [[ -d "web" && ! -L "web" ]]; then
   mv ${DEPLOY_DEST}/web/ ${DEPLOY_DEST}/docroot/


### PR DESCRIPTION
This needs some testing and feedback before merging.

When deploying, re-run `composer install` with additional flags to remove dev dependencies and generate a static classmap.  This should be pretty quick since everything was already downloaded during the install phase.

Drupal still needs its dynamic autoloader for module/theme/profile classes, but the static classmap can improve performance of loading any classes within `/vendor/` and `/web/core/lib`.