### PR TITLE
Update Travis cached directories

### DIFF
--- a/project-scaffold/.travis.yml
+++ b/project-scaffold/.travis.yml
@@ -8,8 +8,8 @@ cache:
   directories:
     - $HOME/.rvm
     - $HOME/.buildcache
-    - $HOME/.composer
-    - $HOME/.drush/cache
+    - $HOME/.composer/cache/files
+    - $HOME/.composer/cache/vcs
 branches:
   only:
     - 8.2.x


### PR DESCRIPTION
- #26 Introduced a requirement for Drush 9+, and `$HOME/.drush` is only used by older versions
- Other composer cache directories have a lot of file churn, causing the cache to be updated on each build.  This only stores the more stable cache of dependency releases and repositories, reducing build times.